### PR TITLE
ci: use 'oracle-actions/setup-java@v1' instead of 'actions/setup-java@v3' and add jdk 19 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,15 +90,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java-version: [ 17, 18 ]
+        java-version: [ 17, 18, 19 ]
         os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3
+#      - name: Set up JDK
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'zulu'
+#          java-version: ${{ matrix.java-version }}
+      - name: 'Set up latest JDK ${{ matrix.java-version }} from jdk.java.net'
+        uses: oracle-actions/setup-java@v1
         with:
-          distribution: 'zulu'
-          java-version: ${{ matrix.java-version }}
+          website: jdk.java.net
+          release: ${{ matrix.java-version }}
       - name: Cache Maven packages
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
## Summary
<!-- What are the changes supposed to accomplish? -->
use 'oracle-actions/setup-java@v1' instead of 'actions/setup-java@v3' and add jdk 19 support

### Changelog
<!-- Describe the updates to accomplish the above changes. -->
1.   use 'oracle-actions/setup-java@v1' instead of 'actions/setup-java@v3'
2.  add jdk 19 support

## Checklist
* **Are tests written for added code?**
<!-- If not, why not? -->
- [ ] Yes
- [ ] No because:

* **Did you introduce any new dependencies?**
<!-- If so, which ones? -->
- [ ] No
- [ ] Yes
  - Dependency:
  - Reason:
